### PR TITLE
Fix filename for Windows

### DIFF
--- a/src/main/java/net/jonathangiles/tool/maven/dependencies/Main.java
+++ b/src/main/java/net/jonathangiles/tool/maven/dependencies/Main.java
@@ -150,7 +150,9 @@ public class Main {
         System.out.print("   Downloading...");
         try {
             URL url = new URL(pomPath);
-            File outputFile = new File("temp/" + project.getFullProjectName() + "/pom.xml");
+            String f = "temp/" + project.getFullProjectName() + "/pom.xml";
+            f = f.replace(":", "-");
+            File outputFile = new File(f);
             outputFile.getParentFile().mkdirs();
             ReadableByteChannel rbc = Channels.newChannel(url.openStream());
             FileOutputStream fos = new FileOutputStream(outputFile);


### PR DESCRIPTION
Filenames cannot include colons on Windows.  Replace colons with a dash.

This is a PR for [Issue 1](https://github.com/JonathanGiles/DependencyChecker/issues/1).