### PR TITLE
Fix project name issue

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -7,12 +7,12 @@
     <parent>
         <groupId>net.jonathangiles.tools</groupId>
         <artifactId>dependencyChecker-parent</artifactId>
-        <version>1.0.4</version>
+        <version>1.0.5</version>
     </parent>
 
     <groupId>net.jonathangiles.tools</groupId>
     <artifactId>dependencyChecker-core</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
 
     <name>Dependency Checker - Core</name>
     <description>A Maven dependency checker and report tool for identifying dependency convergence issues.</description>

--- a/core/src/main/java/net/jonathangiles/tool/maven/dependencies/Main.java
+++ b/core/src/main/java/net/jonathangiles/tool/maven/dependencies/Main.java
@@ -139,7 +139,7 @@ public class Main {
     protected List<Project> loadProjects(File inputFile) {
         if (inputFile.getName().endsWith(".xml")) {
             // we are being given a pom file directly
-            final Project project = new WebProject(inputFile.getName(), analyseBom);
+            final Project project = new WebProject(getFileNameWithoutExtension(inputFile.getName()), analyseBom);
             project.getPomUrls().add(inputFile.getAbsolutePath());
             return Collections.singletonList(project);
         } else {
@@ -155,6 +155,14 @@ public class Main {
                 return Collections.emptyList();
             }
         }
+    }
+
+    private String getFileNameWithoutExtension(String filename) {
+        int index = filename.lastIndexOf('.');
+        if (index == -1) {
+            return filename;
+        }
+        return filename.substring(0, index);
     }
 
     private Optional<Result> runScan(File inputFile) {
@@ -286,6 +294,7 @@ public class Main {
     }
 
     private Optional<File> downloadPom(Project project, String pomPath) {
+        System.out.println("The project name is " + project.getFullProjectName());
         final String f = ("temp/" + project.getFullProjectName() + "/pom.xml").replace(":", "-");
         final File outputFile = new File(f);
         outputFile.getParentFile().mkdirs();

--- a/core/src/main/java/net/jonathangiles/tool/maven/dependencies/project/MavenReleasedProject.java
+++ b/core/src/main/java/net/jonathangiles/tool/maven/dependencies/project/MavenReleasedProject.java
@@ -2,7 +2,6 @@ package net.jonathangiles.tool.maven.dependencies.project;
 
 import net.jonathangiles.tool.maven.dependencies.misc.Util;
 import net.jonathangiles.tool.maven.dependencies.model.Version;
-import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/core/src/main/java/net/jonathangiles/tool/maven/dependencies/project/WebProject.java
+++ b/core/src/main/java/net/jonathangiles/tool/maven/dependencies/project/WebProject.java
@@ -1,7 +1,6 @@
 package net.jonathangiles.tool.maven.dependencies.project;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Stack;
 

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.jonathangiles.tools</groupId>
         <artifactId>dependencyChecker-parent</artifactId>
-        <version>1.0.4</version>
+        <version>1.0.5</version>
     </parent>
 
     <name>Dependency Checker - Maven Plugin</name>
@@ -16,7 +16,7 @@
 
     <groupId>net.jonathangiles.tools</groupId>
     <artifactId>dependencyChecker-maven-plugin</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
     <packaging>maven-plugin</packaging>
 
     <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.jonathangiles.tools</groupId>
     <artifactId>dependencyChecker-parent</artifactId>
-    <version>1.0.4</version>
+    <version>1.0.5</version>
     <packaging>pom</packaging>
 
     <name>Dependency Checker - Parent</name>


### PR DESCRIPTION
When `pom.xml` is given as the input file, a `WebProject` instance is created with the project name as `pom.xml`. So, when a temp pom file is created by [downloadPom](https://github.com/JonathanGiles/DependencyChecker/blob/master/core/src/main/java/net/jonathangiles/tool/maven/dependencies/Main.java#L289) method, a file is created in `<rootdir>/pom.xml/pom.xml`. This causes an issue with [whitelist generator](https://github.com/JonathanGiles/whitelistgenerator/blob/master/core/src/main/java/net/jonathangiles/tools/maven/whitelistgenerator/Main.java#L84) that scans all files ending with `.xml`.

So, the fix here is to remove the file extension when creating the `WebProject` instance.